### PR TITLE
Initial modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    powerplatform = {
+      source  = "microsoft/power-platform"
+    }
+  }
+}
+
+
+resource "powerplatform_environment" "sandbox" {
+  location          = "unitedstates"
+  language_code     = 1033
+  display_name      = "terraformsandbox"
+  currency_code     = "USD"
+  environment_type  = "Sandbox"
+  security_group_id = var.environment_access_group_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,4 @@
+variable "environment_access_group_id" {
+  description = "The id of the environment Entra security access group"
+  type        = string
+}


### PR DESCRIPTION
This pull request primarily focuses on the addition of a new Terraform configuration for a Power Platform environment. The changes include the configuration of required providers and the definition of a new Power Platform environment resource in `main.tf`, as well as the introduction of a new variable in `variables.tf`.

Addition of Terraform configuration:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR1-R17): Added the Terraform configuration for a Power Platform environment. The configuration includes the required providers block, specifying the Power Platform provider from Microsoft, and a new resource block for a Power Platform environment. The environment is of type "Sandbox" and its settings like location, language code, display name, and currency code are defined. The `security_group_id` for the environment is set to reference a variable `environment_access_group_id`.

Addition of new variable:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR1-R4): Introduced a new variable `environment_access_group_id`. This variable is of type string and is described as "The id of the environment Entra security access group". It is used in `main.tf` to set the `security_group_id` for the Power Platform environment.